### PR TITLE
Add ability for enemies to get re-pathed.

### DIFF
--- a/assets/prefabs/gooey.prefab
+++ b/assets/prefabs/gooey.prefab
@@ -1,5 +1,4 @@
 {
-  /* Gooey must not be unloaded, as otherwise we spawn a new one */
   "alwaysRelevant": true,
   "DisplayName": {
     "name": "Gooey",
@@ -61,6 +60,8 @@
   },
   "InteractionTarget": {},
   "Gooey": {
+  },
+  "Movement": {
     "speed": 3
   }
 }

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -39,6 +39,7 @@ import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
 
@@ -193,7 +194,7 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
         PathComponent pathComponent = getPathComponent(entity);
         LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
 
-        float dist = locationComponent.getWorldPosition().distanceSquared(pathComponent.getGoal());
+        float dist = locationComponent.getWorldPosition().distanceSquared(pathComponent.getGoal().toVector3f());
         if (dist < 0.1f) {
             updateToNextStep(entity, pathComponent);
         } else {
@@ -230,7 +231,7 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
     private void moveEnemyTowardsGoal(EntityRef entity, PathComponent pathComponent, LocationComponent locationComponent, float delta) {
         MovementComponent movementComponent = entity.getComponent(MovementComponent.class);
         /* Calculate required heading */
-        Vector3f target = new Vector3f(pathComponent.getGoal());
+        Vector3f target = pathComponent.getGoal().toVector3f();
         target.sub(locationComponent.getWorldPosition());
         target.normalize();
         /* Scale to the speed */

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -74,7 +74,7 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
         } else if (entity.hasComponent(BlankPathComponent.class)) {
             return entity.getComponent(BlankPathComponent.class);
         } else {
-            throw new Error("Enemy with no Path Component Requested.");
+            throw new Error("Path Component requested on entity that lacks one.");
         }
     }
 

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -31,7 +31,7 @@ import org.terasology.gooeyDefence.components.enemies.MovementComponent;
 import org.terasology.gooeyDefence.components.enemies.PathComponent;
 import org.terasology.gooeyDefence.events.DamageShrineEvent;
 import org.terasology.gooeyDefence.events.OnFieldActivated;
-import org.terasology.gooeyDefence.events.OnPathChanged;
+import org.terasology.gooeyDefence.events.OnEntrancePathChanged;
 import org.terasology.gooeyDefence.events.RepathEnemyRequest;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.delay.DelayManager;
@@ -117,10 +117,10 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
     /**
      * Called when the a path is changed.
      *
-     * @see OnPathChanged
+     * @see OnEntrancePathChanged
      */
     @ReceiveEvent
-    public void onPathChanged(OnPathChanged event, EntityRef shrineEntity) {
+    public void onPathChanged(OnEntrancePathChanged event, EntityRef shrineEntity) {
         for (EntityRef enemy : enemies) {
             /* Firstly check if the enemy is on an unchanged path */
             if (enemy.hasComponent(EntrancePathComponent.class)) {

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -31,6 +31,7 @@ import org.terasology.gooeyDefence.components.enemies.MovementComponent;
 import org.terasology.gooeyDefence.components.enemies.PathComponent;
 import org.terasology.gooeyDefence.events.DamageShrineEvent;
 import org.terasology.gooeyDefence.events.OnFieldActivated;
+import org.terasology.gooeyDefence.events.OnPathChanged;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
@@ -96,6 +97,16 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
                 spawnEnemy(i);
             }
         }
+    }
+
+    /**
+     * Called when the a path is changed.
+     *
+     * @see OnPathChanged
+     */
+    @ReceiveEvent
+    public void onPathChanged(OnPathChanged event, EntityRef entity) {
+        logger.info(event.getPathId() + "");
     }
 
     /**

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -118,7 +118,7 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
         for (EntityRef enemy : enemies) {
             /* Firstly check if the enemy is on an unchanged path */
             if (enemy.hasComponent(EntrancePathComponent.class)) {
-                if (enemy.getComponent(EntrancePathComponent.class).getEntranceID() != event.getPathId()) {
+                if (enemy.getComponent(EntrancePathComponent.class).getEntranceId() != event.getPathId()) {
                     return;
                 }
             }
@@ -209,8 +209,8 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
         PathComponent pathComponent = getPathComponent(entity);
         LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
 
-        float dist = locationComponent.getWorldPosition().distanceSquared(pathComponent.getGoal().toVector3f());
-        if (dist < 0.1f) {
+        float distSqr = locationComponent.getWorldPosition().distanceSquared(pathComponent.getGoal().toVector3f());
+        if (distSqr < 0.1f) {
             updateToNextStep(entity, pathComponent);
         } else {
             moveEnemyTowardsGoal(entity, pathComponent, locationComponent, delta);

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -81,6 +81,9 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
     public void onFieldActivated(OnFieldActivated event, EntityRef entity) {
         enemies.clear();
         entityManager.getEntitiesWith(GooeyComponent.class).forEach(enemies::add);
+        enemies.stream().filter(enemy->enemy.hasComponent(EntrancePathComponent.class))
+                .forEach(enemy->enemy.getComponent(EntrancePathComponent.class).setPathManager(pathfindingSystem));
+
         //delayManager.addPeriodicAction(DefenceField.getShrineEntity(), "SpawnEnemyEvent", 500, 500);
     }
 

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -18,14 +18,13 @@ package org.terasology.gooeyDefence;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
-import org.terasology.gooeyDefence.components.enemies.BlankPathComponent;
-import org.terasology.gooeyDefence.components.enemies.CustomPathComponent;
 import org.terasology.gooeyDefence.components.enemies.EntrancePathComponent;
 import org.terasology.gooeyDefence.components.enemies.GooeyComponent;
 import org.terasology.gooeyDefence.components.enemies.MovementComponent;
@@ -65,17 +64,24 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
     @In
     private DelayManager delayManager;
 
+    /**
+     * Get the PathComponent used on the entity.
+     * <p>
+     * An entity should only have one implementation of the path component.
+     * As such, this method makes no guarantee about which component will be returned if the
+     * entity has multiple implementations.
+     *
+     * @param entity The entity to look on
+     * @return The first path component found on the entity.
+     * @throws IllegalArgumentException If the entity lacks a PathComponent
+     */
     public static PathComponent getPathComponent(EntityRef entity) {
-        //TODO: Make this less ugly. Dynamically obtain path components via reflection?
-        if (entity.hasComponent(EntrancePathComponent.class)) {
-            return entity.getComponent(EntrancePathComponent.class);
-        } else if (entity.hasComponent(CustomPathComponent.class)) {
-            return entity.getComponent(CustomPathComponent.class);
-        } else if (entity.hasComponent(BlankPathComponent.class)) {
-            return entity.getComponent(BlankPathComponent.class);
-        } else {
-            throw new Error("Path Component requested on entity that lacks one.");
+        for (Component component : entity.iterateComponents()) {
+            if (component instanceof PathComponent) {
+                return (PathComponent) component;
+            }
         }
+        throw new IllegalArgumentException("Path Component requested on entity that lacks one.");
     }
 
     /**

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -112,16 +112,16 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
      * @see OnPathChanged
      */
     @ReceiveEvent
-    public void onPathChanged(OnPathChanged event, EntityRef entity) {
+    public void onPathChanged(OnPathChanged event, EntityRef shrineEntity) {
         enemies.forEach(enemy -> {
             /* If entity is on the path that changes */
-            if (entity.hasComponent(EntrancePathComponent.class)) {
-                if (entity.getComponent(EntrancePathComponent.class).getEntranceID() == event.getPathId()) {
-                    entity.send(new RepathEnemyRequest());
+            if (enemy.hasComponent(EntrancePathComponent.class)) {
+                if (enemy.getComponent(EntrancePathComponent.class).getEntranceID() == event.getPathId()) {
+                    enemy.send(new RepathEnemyRequest());
                 }
                 /* If the enemy wasn't on an entrance path */
             } else {
-                entity.send(new RepathEnemyRequest());
+                enemy.send(new RepathEnemyRequest());
             }
         });
     }

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -24,6 +24,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.gooeyDefence.components.enemies.BlankPathComponent;
 import org.terasology.gooeyDefence.components.enemies.CustomPathComponent;
 import org.terasology.gooeyDefence.components.enemies.EntrancePathComponent;
 import org.terasology.gooeyDefence.components.enemies.GooeyComponent;
@@ -68,6 +69,8 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
             return entity.getComponent(EntrancePathComponent.class);
         } else if (entity.hasComponent(CustomPathComponent.class)) {
             return entity.getComponent(CustomPathComponent.class);
+        } else if (entity.hasComponent(BlankPathComponent.class)) {
+            return entity.getComponent(BlankPathComponent.class);
         } else {
             throw new Error("Enemy with no Path Component Requested.");
         }
@@ -81,8 +84,8 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
     public void onFieldActivated(OnFieldActivated event, EntityRef entity) {
         enemies.clear();
         entityManager.getEntitiesWith(GooeyComponent.class).forEach(enemies::add);
-        enemies.stream().filter(enemy->enemy.hasComponent(EntrancePathComponent.class))
-                .forEach(enemy->enemy.getComponent(EntrancePathComponent.class).setPathManager(pathfindingSystem));
+        enemies.stream().filter(enemy -> enemy.hasComponent(EntrancePathComponent.class))
+                .forEach(enemy -> enemy.getComponent(EntrancePathComponent.class).setPathManager(pathfindingSystem));
 
         //delayManager.addPeriodicAction(DefenceField.getShrineEntity(), "SpawnEnemyEvent", 500, 500);
     }

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -32,6 +32,7 @@ import org.terasology.gooeyDefence.components.enemies.PathComponent;
 import org.terasology.gooeyDefence.events.DamageShrineEvent;
 import org.terasology.gooeyDefence.events.OnFieldActivated;
 import org.terasology.gooeyDefence.events.OnPathChanged;
+import org.terasology.gooeyDefence.events.RepathEnemyRequest;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
@@ -106,7 +107,17 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
      */
     @ReceiveEvent
     public void onPathChanged(OnPathChanged event, EntityRef entity) {
-        logger.info(event.getPathId() + "");
+        enemies.forEach(enemy -> {
+            /* If entity is on the path that changes */
+            if (entity.hasComponent(EntrancePathComponent.class)) {
+                if (entity.getComponent(EntrancePathComponent.class).getEntranceID() == event.getPathId()) {
+                    entity.send(new RepathEnemyRequest());
+                }
+                /* If the enemy wasn't on an entrance path */
+            } else {
+                entity.send(new RepathEnemyRequest());
+            }
+        });
     }
 
     /**
@@ -122,7 +133,7 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
 
         EntityRef entity = entityManager.create("GooeyDefence:Gooey", DefenceField.entrancePos(entranceNumber).toVector3f());
 
-        /* Setup movement component */
+        /* Setup pathfinding component */
         EntrancePathComponent component = new EntrancePathComponent(entranceNumber, pathfindingSystem);
         entity.addComponent(component);
 

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -200,18 +200,19 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
     @Override
     public void update(float delta) {
         if (DefenceField.isFieldActivated()) {
-            enemies.forEach(entity -> processEnemy(entity, delta));
+            enemies.forEach(entity -> moveEnemyAlongPath(entity, delta));
             enemiesToRemove.forEach(enemies::remove);
             enemiesToRemove.clear();
         }
     }
 
     /**
-     * Moves an enemy along it's path.
+     * Moves an enemy one step along it's path.
+     * Also handles the enemy reaching the end of the path.
      *
      * @param entity the enemy to move
      */
-    private void processEnemy(EntityRef entity, float delta) {
+    private void moveEnemyAlongPath(EntityRef entity, float delta) {
         PathComponent pathComponent = getPathComponent(entity);
         LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
 

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -136,7 +136,7 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
                         newPath.indexOf(goal));
                 enemy.addComponent(entranceComponent);
             } else {
-                /* It's had it's path change and it isn't on the new path */
+                /* It's had its path change and it isn't on the new path */
                 enemy.send(new RepathEnemyRequest());
             }
         }
@@ -241,7 +241,7 @@ public class EnemyManager extends BaseComponentSystem implements UpdateSubscribe
      * @param entity            The entity to move
      * @param pathComponent     The GooeyComponent of the entity
      * @param locationComponent The LocationComponent of the entity
-     * @param delta             The delta of this step
+     * @param delta             The time elapsed since the last call (in ms)
      */
     private void moveEnemyTowardsGoal(EntityRef entity, PathComponent pathComponent, LocationComponent locationComponent, float delta) {
         MovementComponent movementComponent = entity.getComponent(MovementComponent.class);

--- a/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
@@ -94,17 +94,20 @@ public class PathfindingSystem extends BaseComponentSystem {
      * @param callback A callback to be invoked after the path calculation has finished.
      */
     private void calculatePath(int id, Runnable callback) {
-        pathfinderSystem.requestPath(
-                DefenceField.fieldCentre(), DefenceField.entrancePos(id), (path, end) -> {
-                    List<Vector3i> oldPath = paths.get(id);
-                    paths.set(id, path);
-                    if (oldPath != null && !oldPath.equals(path)) {
-                        DefenceField.getShrineEntity().send(new OnPathChanged(id, path));
-                    }
-                    if (callback != null) {
-                        callback.run();
-                    }
-                });
+        calculatePath(DefenceField.entrancePos(id), (path, end) -> {
+            List<Vector3i> oldPath = paths.get(id);
+            paths.set(id, path);
+            if (oldPath != null && !oldPath.equals(path)) {
+                DefenceField.getShrineEntity().send(new OnPathChanged(id, path));
+            }
+            if (callback != null) {
+                callback.run();
+            }
+        });
+    }
+
+    private void calculatePath(Vector3i startPoint, BiConsumer<List<Vector3i>, Vector3i> callback) {
+        pathfinderSystem.requestPath(DefenceField.fieldCentre(), startPoint, callback::accept);
     }
 
     /**

--- a/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
@@ -94,7 +94,7 @@ public class PathfindingSystem extends BaseComponentSystem {
 
         /* Process its path */
         calculatePath(new Vector3i(locationComponent.getWorldPosition()), (path, end) -> {
-            if (path.size() != 0) {
+            if (!path.isEmpty()) {
                 CustomPathComponent customPathComponent = new CustomPathComponent(path);
                 entity.addComponent(customPathComponent);
                 entity.removeComponent(BlankPathComponent.class);

--- a/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 
 @Share(PathfindingSystem.class)
 @RegisterSystem
@@ -91,14 +90,12 @@ public class PathfindingSystem extends BaseComponentSystem {
     public void onRepathEnemyRequest(RepathEnemyRequest event, EntityRef entity, LocationComponent locationComponent) {
         /* Pause the enemy */
         entity.removeComponent(EnemyManager.getPathComponent(entity).getClass());
-        entity.addComponent(new BlankPathComponent(locationComponent.getWorldPosition()));
+        entity.addComponent(new BlankPathComponent(new Vector3i(locationComponent.getWorldPosition())));
 
         /* Process it's path */
         calculatePath(new Vector3i(locationComponent.getWorldPosition()), (path, end) -> {
             if (path.size() != 0) {
-                CustomPathComponent customPathComponent = new CustomPathComponent(path.stream()
-                        .map(Vector3i::toVector3f)
-                        .collect(Collectors.toList()));
+                CustomPathComponent customPathComponent = new CustomPathComponent(path);
                 entity.addComponent(customPathComponent);
                 entity.removeComponent(BlankPathComponent.class);
             }

--- a/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
@@ -92,7 +92,7 @@ public class PathfindingSystem extends BaseComponentSystem {
         entity.removeComponent(EnemyManager.getPathComponent(entity).getClass());
         entity.addComponent(new BlankPathComponent(new Vector3i(locationComponent.getWorldPosition())));
 
-        /* Process it's path */
+        /* Process its path */
         calculatePath(new Vector3i(locationComponent.getWorldPosition()), (path, end) -> {
             if (path.size() != 0) {
                 CustomPathComponent customPathComponent = new CustomPathComponent(path);

--- a/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
@@ -25,7 +25,7 @@ import org.terasology.flexiblepathfinding.PathfinderSystem;
 import org.terasology.gooeyDefence.components.enemies.BlankPathComponent;
 import org.terasology.gooeyDefence.components.enemies.CustomPathComponent;
 import org.terasology.gooeyDefence.events.OnFieldActivated;
-import org.terasology.gooeyDefence.events.OnPathChanged;
+import org.terasology.gooeyDefence.events.OnEntrancePathChanged;
 import org.terasology.gooeyDefence.events.RepathEnemyRequest;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3i;
@@ -113,7 +113,7 @@ public class PathfindingSystem extends BaseComponentSystem {
             List<Vector3i> oldPath = paths.get(id);
             paths.set(id, path);
             if (oldPath != null && !oldPath.equals(path)) {
-                DefenceField.getShrineEntity().send(new OnPathChanged(id, path));
+                DefenceField.getShrineEntity().send(new OnEntrancePathChanged(id, path));
             }
             if (callback != null) {
                 callback.run();

--- a/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
@@ -42,7 +42,7 @@ public class PathfindingSystem extends BaseComponentSystem {
 
     @In
     private PathfinderSystem pathfinderSystem;
-    private List<List<Vector3i>> paths = new ArrayList<>(Collections.nCopies(DefenceField.entranceCount(), new ArrayList<Vector3i>()));
+    private List<List<Vector3i>> paths = new ArrayList<>(Collections.nCopies(DefenceField.entranceCount(), null));
 
 
     /**
@@ -96,8 +96,9 @@ public class PathfindingSystem extends BaseComponentSystem {
     private void calculatePath(int id, Runnable callback) {
         pathfinderSystem.requestPath(
                 DefenceField.fieldCentre(), DefenceField.entrancePos(id), (path, end) -> {
-                    if (!paths.get(id).equals(path)) {
-                        paths.set(id, path);
+                    List<Vector3i> oldPath = paths.get(id);
+                    paths.set(id, path);
+                    if (oldPath != null && !oldPath.equals(path)) {
                         DefenceField.getShrineEntity().send(new OnPathChanged(id, path));
                     }
                     if (callback != null) {

--- a/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
@@ -24,6 +24,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.flexiblepathfinding.PathfinderSystem;
 import org.terasology.gooeyDefence.events.OnFieldActivated;
 import org.terasology.gooeyDefence.events.OnPathChanged;
+import org.terasology.gooeyDefence.events.RepathEnemyRequest;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
@@ -74,6 +75,16 @@ public class PathfindingSystem extends BaseComponentSystem {
         if (DefenceField.isFieldActivated()) {
             calculatePaths();
         }
+    }
+
+    /**
+     * Called to request an enemy be re-pathed. Handles that.
+     *
+     * @see RepathEnemyRequest
+     */
+    @ReceiveEvent
+    public void onRepathEnemyRequest(RepathEnemyRequest event, EntityRef entity) {
+        logger.info("ping");
     }
 
     /**

--- a/src/main/java/org/terasology/gooeyDefence/components/DestructibleBlockComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/DestructibleBlockComponent.java
@@ -17,5 +17,8 @@ package org.terasology.gooeyDefence.components;
 
 import org.terasology.entitySystem.Component;
 
+/**
+ * Marks that a block can be destroyed.
+ */
 public class DestructibleBlockComponent implements Component {
 }

--- a/src/main/java/org/terasology/gooeyDefence/components/ShrineComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/ShrineComponent.java
@@ -18,6 +18,10 @@ package org.terasology.gooeyDefence.components;
 import org.terasology.entitySystem.Component;
 import org.terasology.world.block.ForceBlockActive;
 
+/**
+ * Component for the central shrine entity.
+ * Stores information relating to the shrine and to the general field.
+ */
 @ForceBlockActive
 public class ShrineComponent implements Component {
     private int health;

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/BlankPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/BlankPathComponent.java
@@ -18,7 +18,7 @@ package org.terasology.gooeyDefence.components.enemies;
 import org.terasology.math.geom.Vector3i;
 
 /**
- * Keeps the gooey at a specific location.
+ * Keeps the enemy at a specific location.
  * Used to pause it when a path is being calculated.
  */
 public class BlankPathComponent implements PathComponent {

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/BlankPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/BlankPathComponent.java
@@ -25,7 +25,7 @@ public class BlankPathComponent implements PathComponent {
     private Vector3i position;
 
     /**
-     * empty constructor for deserialisation
+     * Empty constructor for deserialisation.
      */
     private BlankPathComponent() {
 

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/BlankPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/BlankPathComponent.java
@@ -15,14 +15,14 @@
  */
 package org.terasology.gooeyDefence.components.enemies;
 
-import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
 
 /**
  * Keeps the gooey at a specific location.
  * Used to pause it when a path is being calculated.
  */
 public class BlankPathComponent implements PathComponent {
-    private Vector3f position;
+    private Vector3i position;
 
     /**
      * empty constructor for deserialisation
@@ -31,7 +31,7 @@ public class BlankPathComponent implements PathComponent {
 
     }
 
-    public BlankPathComponent(Vector3f position) {
+    public BlankPathComponent(Vector3i position) {
         this.position = position;
     }
 
@@ -42,7 +42,7 @@ public class BlankPathComponent implements PathComponent {
     }
 
     @Override
-    public Vector3f getGoal() {
+    public Vector3i getGoal() {
         return position;
     }
 

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/BlankPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/BlankPathComponent.java
@@ -17,45 +17,42 @@ package org.terasology.gooeyDefence.components.enemies;
 
 import org.terasology.math.geom.Vector3f;
 
-import java.util.List;
-
-public class CustomPathComponent implements PathComponent {
-    private List<Vector3f> path;
-    private int step;
+/**
+ * Keeps the gooey at a specific location.
+ * Used to pause it when a path is being calculated.
+ */
+public class BlankPathComponent implements PathComponent {
+    private Vector3f position;
 
     /**
      * empty constructor for deserialisation
      */
-    private CustomPathComponent() {
+    private BlankPathComponent() {
+
     }
 
-    public CustomPathComponent(List<Vector3f> path) {
-        this.path = path;
-        this.step = path.size() - 1;
+    public BlankPathComponent(Vector3f position) {
+        this.position = position;
     }
 
 
     @Override
     public int getStep() {
-        return step;
+        return 0;
     }
 
     @Override
     public Vector3f getGoal() {
-        if (step >= 1) {
-            return path.get(step - 1);
-        } else {
-            return null;
-        }
+        return position;
     }
 
     @Override
     public void nextStep() {
-        step = Math.min(Math.max(0, step--), path.size() - 1);
+
     }
 
     @Override
     public boolean atEnd() {
-        return step == 0;
+        return false;
     }
 }

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
@@ -20,7 +20,8 @@ import org.terasology.math.geom.Vector3i;
 import java.util.List;
 
 /**
- * Moves the enemy along a path stored internally in the component
+ * Moves the enemy along a path stored internally in the component.
+ * <p>
  * Used for enemies that don't follow the standard entrance path.
  */
 public class CustomPathComponent implements PathComponent {
@@ -28,7 +29,7 @@ public class CustomPathComponent implements PathComponent {
     private int step;
 
     /**
-     * empty constructor for deserialisation
+     * Empty constructor for deserialisation.
      */
     private CustomPathComponent() {
     }

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.gooeyDefence.components.enemies;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
 
 import java.util.List;
@@ -24,6 +23,11 @@ public class CustomPathComponent implements PathComponent {
     private List<Vector3f> path;
     private int step;
 
+    /**
+     * empty constructor for deserialisation
+     */
+    public CustomPathComponent() {
+    }
 
     public CustomPathComponent(List<Vector3f> path) {
         this.path = path;

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.components.enemies;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3f;
+
+import java.util.List;
+
+public class CustomPathComponent implements PathComponent {
+    private List<Vector3f> path;
+    private int step;
+
+
+    public CustomPathComponent(List<Vector3f> path) {
+        this.path = path;
+        this.step = path.size() - 1;
+    }
+
+
+    @Override
+    public int getStep() {
+        return step;
+    }
+
+    @Override
+    public Vector3f getGoal() {
+        if (step >= 1) {
+            return path.get(step + 1);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void nextStep() {
+        step -= step > 0 ? 1 : 0;
+    }
+
+    @Override
+    public boolean atEnd() {
+        return step == 0;
+    }
+}

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
@@ -42,16 +42,13 @@ public class CustomPathComponent implements PathComponent {
 
     @Override
     public Vector3f getGoal() {
-        if (step >= 1) {
-            return path.get(step - 1);
-        } else {
-            return null;
-        }
+        return path.get(step);
     }
 
     @Override
     public void nextStep() {
-        step = Math.min(Math.max(0, step--), path.size() - 1);
+        step--;
+        step = Math.min(Math.max(0, step), path.size() - 1);
     }
 
     @Override

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
@@ -16,11 +16,12 @@
 package org.terasology.gooeyDefence.components.enemies;
 
 import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
 
 import java.util.List;
 
 public class CustomPathComponent implements PathComponent {
-    private List<Vector3f> path;
+    private List<Vector3i> path;
     private int step;
 
     /**
@@ -29,7 +30,7 @@ public class CustomPathComponent implements PathComponent {
     private CustomPathComponent() {
     }
 
-    public CustomPathComponent(List<Vector3f> path) {
+    public CustomPathComponent(List<Vector3i> path) {
         this.path = path;
         this.step = path.size() - 1;
     }
@@ -41,7 +42,7 @@ public class CustomPathComponent implements PathComponent {
     }
 
     @Override
-    public Vector3f getGoal() {
+    public Vector3i getGoal() {
         return path.get(step);
     }
 

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
@@ -43,7 +43,7 @@ public class CustomPathComponent implements PathComponent {
     @Override
     public Vector3f getGoal() {
         if (step >= 1) {
-            return path.get(step + 1);
+            return path.get(step - 1);
         } else {
             return null;
         }
@@ -51,7 +51,7 @@ public class CustomPathComponent implements PathComponent {
 
     @Override
     public void nextStep() {
-        step -= step > 0 ? 1 : 0;
+        step = Math.min(Math.max(0, step--), path.size() - 1);
     }
 
     @Override

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/CustomPathComponent.java
@@ -15,11 +15,14 @@
  */
 package org.terasology.gooeyDefence.components.enemies;
 
-import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 
 import java.util.List;
 
+/**
+ * Moves the enemy along a path stored internally in the component
+ * Used for enemies that don't follow the standard entrance path.
+ */
 public class CustomPathComponent implements PathComponent {
     private List<Vector3i> path;
     private int step;

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -60,7 +60,8 @@ public class EntrancePathComponent implements PathComponent {
     @Override
     public void nextStep() {
         List path = pathManager.getPath(entranceID);
-        step = Math.min(Math.max(0, step--), path.size() - 1);
+        step--;
+        step = Math.min(Math.max(0, step), path.size() - 1);
         goal = pathManager.getPath(entranceID).get(step).toVector3f();
 
     }

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -45,12 +45,16 @@ public class EntrancePathComponent implements PathComponent {
      *
      * @param entranceId  The ID of the entrance
      * @param pathManager The PathfindingSystem the path is stored in
-     * @param startStep   The step to start from.
+     * @param startStep   The step to start from. This must be a valid index in the path.
      */
     public EntrancePathComponent(int entranceId, PathfindingSystem pathManager, int startStep) {
         this.entranceId = entranceId;
         this.pathManager = pathManager;
-        step = Math.max(Math.min(pathManager.getPath(entranceId).size() - 1, startStep), 0);
+        /* The startStep given must be in the range of the path */
+        if (startStep < 0 || startStep > pathManager.getPath(entranceId).size() - 1) {
+            throw new IllegalArgumentException();
+        }
+        step = startStep;
         goal = pathManager.getPath(entranceId).get(step);
     }
 
@@ -63,7 +67,7 @@ public class EntrancePathComponent implements PathComponent {
 
     /**
      * Set the PathfindingSystem the paths are stored in.
-     * Used as the field cannot be serialised.
+     * The field storing it cannot be serialised so it must be manually set.
      *
      * @param pathManager The new path manager to set
      */
@@ -91,7 +95,7 @@ public class EntrancePathComponent implements PathComponent {
     }
 
     /**
-     * @return the ID of the entrance path this component is following.
+     * @return the Id of the entrance path this component is following.
      */
     public int getEntranceId() {
         return entranceId;

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -18,7 +18,6 @@ package org.terasology.gooeyDefence.components.enemies;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.gooeyDefence.PathfindingSystem;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 
 import java.util.List;
@@ -34,6 +33,13 @@ public class EntrancePathComponent implements PathComponent {
      * empty constructor for deserialisation
      */
     private EntrancePathComponent() {
+    }
+
+    public EntrancePathComponent(int entranceID, PathfindingSystem pathManager, int startStep) {
+        this.entranceID = entranceID;
+        this.pathManager = pathManager;
+        step = Math.max(Math.min(pathManager.getPath(entranceID).size() - 1, startStep), 0);
+        goal = pathManager.getPath(entranceID).get(step);
     }
 
     public EntrancePathComponent(int entranceID, PathfindingSystem pathManager) {
@@ -60,10 +66,10 @@ public class EntrancePathComponent implements PathComponent {
 
     @Override
     public void nextStep() {
-        List path = pathManager.getPath(entranceID);
+        List<Vector3i> path = pathManager.getPath(entranceID);
         step--;
         step = Math.min(Math.max(0, step), path.size() - 1);
-        goal = pathManager.getPath(entranceID).get(step);
+        goal = path.get(step);
 
     }
 

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -26,23 +26,20 @@ public class EntrancePathComponent implements PathComponent {
     private static final Logger logger = LoggerFactory.getLogger(EntrancePathComponent.class);
     private int step;
     private int entranceID;
-    private Vector3f goal = Vector3f.zero();
+    private Vector3f goal;
     private PathfindingSystem pathManager;
-
-    public EntrancePathComponent() {
-
-    }
 
     public EntrancePathComponent(int entranceID, PathfindingSystem pathManager) {
         this.entranceID = entranceID;
         this.pathManager = pathManager;
-        step = pathManager.getPath(entranceID).size();
+        step = pathManager.getPath(entranceID).size() - 1;
+        goal = pathManager.getPath(entranceID).get(step).toVector3f();
     }
 
 
     @Override
     public int getStep() {
-        return 0;
+        return step;
     }
 
     @Override

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -29,6 +29,10 @@ public class EntrancePathComponent implements PathComponent {
     private Vector3f goal;
     private PathfindingSystem pathManager;
 
+    /** empty constructor for deserialisation */
+    public EntrancePathComponent() {
+    }
+
     public EntrancePathComponent(int entranceID, PathfindingSystem pathManager) {
         this.entranceID = entranceID;
         this.pathManager = pathManager;

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class EntrancePathComponent implements PathComponent {
     private int step;
-    private int entranceID;
+    private int entranceId;
     private Vector3i goal;
     private PathfindingSystem pathManager;
 
@@ -43,22 +43,22 @@ public class EntrancePathComponent implements PathComponent {
     /**
      * Create a new entrance path component specifying the position along the path to start at.
      *
-     * @param entranceID  The ID of the entrance
+     * @param entranceId  The ID of the entrance
      * @param pathManager The PathfindingSystem the path is stored in
      * @param startStep   The step to start from.
      */
-    public EntrancePathComponent(int entranceID, PathfindingSystem pathManager, int startStep) {
-        this.entranceID = entranceID;
+    public EntrancePathComponent(int entranceId, PathfindingSystem pathManager, int startStep) {
+        this.entranceId = entranceId;
         this.pathManager = pathManager;
-        step = Math.max(Math.min(pathManager.getPath(entranceID).size() - 1, startStep), 0);
-        goal = pathManager.getPath(entranceID).get(step);
+        step = Math.max(Math.min(pathManager.getPath(entranceId).size() - 1, startStep), 0);
+        goal = pathManager.getPath(entranceId).get(step);
     }
 
-    public EntrancePathComponent(int entranceID, PathfindingSystem pathManager) {
-        this.entranceID = entranceID;
+    public EntrancePathComponent(int entranceId, PathfindingSystem pathManager) {
+        this.entranceId = entranceId;
         this.pathManager = pathManager;
-        step = pathManager.getPath(entranceID).size() - 1;
-        goal = pathManager.getPath(entranceID).get(step);
+        step = pathManager.getPath(entranceId).size() - 1;
+        goal = pathManager.getPath(entranceId).get(step);
     }
 
     /**
@@ -83,7 +83,7 @@ public class EntrancePathComponent implements PathComponent {
 
     @Override
     public void nextStep() {
-        List<Vector3i> path = pathManager.getPath(entranceID);
+        List<Vector3i> path = pathManager.getPath(entranceId);
         step--;
         step = Math.min(Math.max(0, step), path.size() - 1);
         goal = path.get(step);
@@ -93,7 +93,7 @@ public class EntrancePathComponent implements PathComponent {
     /**
      * @return the ID of the entrance path this component is following.
      */
-    public int getEntranceID() {
-        return entranceID;
+    public int getEntranceId() {
+        return entranceId;
     }
 }

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -15,15 +15,20 @@
  */
 package org.terasology.gooeyDefence.components.enemies;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.gooeyDefence.PathfindingSystem;
 import org.terasology.math.geom.Vector3i;
 
 import java.util.List;
 
+/**
+ * Moves the enemy along a path from an entrance to the shrine.
+ * <p>
+ * Doesn't store the path internally to reduce on memory, instead stores a
+ * reference to the PathfindingSystem that holds the path.
+ *
+ * @see PathfindingSystem
+ */
 public class EntrancePathComponent implements PathComponent {
-    private static final Logger logger = LoggerFactory.getLogger(EntrancePathComponent.class);
     private int step;
     private int entranceID;
     private Vector3i goal;
@@ -35,6 +40,13 @@ public class EntrancePathComponent implements PathComponent {
     private EntrancePathComponent() {
     }
 
+    /**
+     * Create a new entrance path component specifying the position along the path to start at.
+     *
+     * @param entranceID  The ID of the entrance
+     * @param pathManager The PathfindingSystem the path is stored in
+     * @param startStep   The step to start from.
+     */
     public EntrancePathComponent(int entranceID, PathfindingSystem pathManager, int startStep) {
         this.entranceID = entranceID;
         this.pathManager = pathManager;
@@ -49,7 +61,12 @@ public class EntrancePathComponent implements PathComponent {
         goal = pathManager.getPath(entranceID).get(step);
     }
 
-
+    /**
+     * Set the PathfindingSystem the paths are stored in.
+     * Used as the field cannot be serialised.
+     *
+     * @param pathManager The new path manager to set
+     */
     public void setPathManager(PathfindingSystem pathManager) {
         this.pathManager = pathManager;
     }
@@ -73,11 +90,9 @@ public class EntrancePathComponent implements PathComponent {
 
     }
 
-    @Override
-    public boolean atEnd() {
-        return step == 0;
-    }
-
+    /**
+     * @return the ID of the entrance path this component is following.
+     */
     public int getEntranceID() {
         return entranceID;
     }

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -29,7 +29,9 @@ public class EntrancePathComponent implements PathComponent {
     private Vector3f goal;
     private PathfindingSystem pathManager;
 
-    /** empty constructor for deserialisation */
+    /**
+     * empty constructor for deserialisation
+     */
     public EntrancePathComponent() {
     }
 
@@ -40,6 +42,10 @@ public class EntrancePathComponent implements PathComponent {
         goal = pathManager.getPath(entranceID).get(step).toVector3f();
     }
 
+
+    public void setPathManager(PathfindingSystem pathManager) {
+        this.pathManager = pathManager;
+    }
 
     @Override
     public int getStep() {
@@ -65,7 +71,7 @@ public class EntrancePathComponent implements PathComponent {
 
     @Override
     public boolean atEnd() {
-        return false;
+        return step == 0;
     }
 
     public int getEntranceID() {

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.gooeyDefence.PathfindingSystem;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
 
 import java.util.List;
 
@@ -26,7 +27,7 @@ public class EntrancePathComponent implements PathComponent {
     private static final Logger logger = LoggerFactory.getLogger(EntrancePathComponent.class);
     private int step;
     private int entranceID;
-    private Vector3f goal;
+    private Vector3i goal;
     private PathfindingSystem pathManager;
 
     /**
@@ -39,7 +40,7 @@ public class EntrancePathComponent implements PathComponent {
         this.entranceID = entranceID;
         this.pathManager = pathManager;
         step = pathManager.getPath(entranceID).size() - 1;
-        goal = pathManager.getPath(entranceID).get(step).toVector3f();
+        goal = pathManager.getPath(entranceID).get(step);
     }
 
 
@@ -53,7 +54,7 @@ public class EntrancePathComponent implements PathComponent {
     }
 
     @Override
-    public Vector3f getGoal() {
+    public Vector3i getGoal() {
         return goal;
     }
 
@@ -62,7 +63,7 @@ public class EntrancePathComponent implements PathComponent {
         List path = pathManager.getPath(entranceID);
         step--;
         step = Math.min(Math.max(0, step), path.size() - 1);
-        goal = pathManager.getPath(entranceID).get(step).toVector3f();
+        goal = pathManager.getPath(entranceID).get(step);
 
     }
 

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -32,7 +32,7 @@ public class EntrancePathComponent implements PathComponent {
     /**
      * empty constructor for deserialisation
      */
-    public EntrancePathComponent() {
+    private EntrancePathComponent() {
     }
 
     public EntrancePathComponent(int entranceID, PathfindingSystem pathManager) {

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -60,11 +60,7 @@ public class EntrancePathComponent implements PathComponent {
     @Override
     public void nextStep() {
         List path = pathManager.getPath(entranceID);
-        step -= step > 0 ? 1 : 0;
-        if (step >= path.size()) {
-            step = path.size() - 1;
-            logger.error("Step greater than path size.");
-        }
+        step = Math.min(Math.max(0, step--), path.size() - 1);
         goal = pathManager.getPath(entranceID).get(step).toVector3f();
 
     }

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -35,7 +35,7 @@ public class EntrancePathComponent implements PathComponent {
     private PathfindingSystem pathManager;
 
     /**
-     * empty constructor for deserialisation
+     * Empty constructor for deserialisation.
      */
     private EntrancePathComponent() {
     }

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/EntrancePathComponent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.components.enemies;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.gooeyDefence.PathfindingSystem;
+import org.terasology.math.geom.Vector3f;
+
+import java.util.List;
+
+public class EntrancePathComponent implements PathComponent {
+    private static final Logger logger = LoggerFactory.getLogger(EntrancePathComponent.class);
+    private int step;
+    private int entranceID;
+    private Vector3f goal = Vector3f.zero();
+    private PathfindingSystem pathManager;
+
+    public EntrancePathComponent() {
+
+    }
+
+    public EntrancePathComponent(int entranceID, PathfindingSystem pathManager) {
+        this.entranceID = entranceID;
+        this.pathManager = pathManager;
+        step = pathManager.getPath(entranceID).size();
+    }
+
+
+    @Override
+    public int getStep() {
+        return 0;
+    }
+
+    @Override
+    public Vector3f getGoal() {
+        return goal;
+    }
+
+    @Override
+    public void nextStep() {
+        List path = pathManager.getPath(entranceID);
+        step -= step > 0 ? 1 : 0;
+        if (step >= path.size()) {
+            step = path.size() - 1;
+            logger.error("Step greater than path size.");
+        }
+        goal = pathManager.getPath(entranceID).get(step).toVector3f();
+
+    }
+
+    @Override
+    public boolean atEnd() {
+        return false;
+    }
+
+    public int getEntranceID() {
+        return entranceID;
+    }
+}

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/GooeyComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/GooeyComponent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.components.enemies;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3f;
+
+public class GooeyComponent implements Component {
+    public int damage;
+}

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/GooeyComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/GooeyComponent.java
@@ -18,6 +18,10 @@ package org.terasology.gooeyDefence.components.enemies;
 import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
 
+/**
+ * General purpose catch all component.
+ * Intended only to be used temporarily to store fields whilst they haven't got their own component
+ */
 public class GooeyComponent implements Component {
     public int damage;
 }

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/MovementComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/MovementComponent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.components.enemies;
+
+import org.terasology.entitySystem.Component;
+
+public class MovementComponent implements Component {
+    private int speed;
+
+    public int getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(int speed) {
+        this.speed = speed;
+    }
+}

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/MovementComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/MovementComponent.java
@@ -17,6 +17,9 @@ package org.terasology.gooeyDefence.components.enemies;
 
 import org.terasology.entitySystem.Component;
 
+/**
+ * Stores information on how to move the enemy.
+ */
 public class MovementComponent implements Component {
     private int speed;
 

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/PathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/PathComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.gooeyDefence.components;
+package org.terasology.gooeyDefence.components.enemies;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
 
-public class GooeyComponent implements Component {
-    public int currentStep;
-    public int pathId;
-    public Vector3f goal = Vector3f.zero();
-    public int speed;
-    public int damage;
+public interface PathComponent extends Component {
+
+
+    int getStep();
+
+    Vector3f getGoal();
+
+    void nextStep();
+
+    boolean atEnd();
+
 }

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/PathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/PathComponent.java
@@ -16,14 +16,14 @@
 package org.terasology.gooeyDefence.components.enemies;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
 
 public interface PathComponent extends Component {
 
 
     int getStep();
 
-    Vector3f getGoal();
+    Vector3i getGoal();
 
     void nextStep();
 

--- a/src/main/java/org/terasology/gooeyDefence/components/enemies/PathComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/enemies/PathComponent.java
@@ -18,15 +18,36 @@ package org.terasology.gooeyDefence.components.enemies;
 import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3i;
 
+/**
+ * A component that marks a path for the enemy to follow.
+ * Intended to have multiple implementations for different pathfollowing situations.
+ */
 public interface PathComponent extends Component {
 
-
+    /**
+     * Step zero must be the end of the path.
+     *
+     * @return The current step of the path
+     */
     int getStep();
 
+    /**
+     * @return the current block the enemy is moving towards
+     */
     Vector3i getGoal();
 
+    /**
+     * Advance internal counters to the next step.
+     */
     void nextStep();
 
-    boolean atEnd();
+    /**
+     * Check if the enemy is at the end of the path.
+     * Step zero must indicate the end.
+     * @return If the enemy is at step zero.
+     */
+    default boolean atEnd() {
+        return getStep() == 0;
+    }
 
 }

--- a/src/main/java/org/terasology/gooeyDefence/components/towers/TowerComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/towers/TowerComponent.java
@@ -20,6 +20,9 @@ import org.terasology.entitySystem.Component;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Component storing the ID's of all the blocks that make up a tower.
+ */
 public class TowerComponent implements Component {
     public Set<Long> cores = new HashSet<>();
     public Set<Long> effects = new HashSet<>();

--- a/src/main/java/org/terasology/gooeyDefence/components/towers/TowerMultiBlockComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/towers/TowerMultiBlockComponent.java
@@ -16,12 +16,16 @@
 package org.terasology.gooeyDefence.components.towers;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.world.block.ForceBlockActive;
 
+/**
+ * Stores a reference to the entity this block belongs to.
+ */
 @ForceBlockActive
 public class TowerMultiBlockComponent implements Component {
     private long towerEntity = -1;
-
+    
     public long getTowerEntity() {
         return towerEntity;
     }

--- a/src/main/java/org/terasology/gooeyDefence/events/OnEntrancePathChanged.java
+++ b/src/main/java/org/terasology/gooeyDefence/events/OnEntrancePathChanged.java
@@ -20,11 +20,11 @@ import org.terasology.math.geom.Vector3i;
 
 import java.util.List;
 
-public class OnPathChanged implements Event {
+public class OnEntrancePathChanged implements Event {
     private int pathId;
     private List<Vector3i> newPath;
 
-    public OnPathChanged(int pathId, List<Vector3i> newPath) {
+    public OnEntrancePathChanged(int pathId, List<Vector3i> newPath) {
         this.pathId = pathId;
         this.newPath = newPath;
     }

--- a/src/main/java/org/terasology/gooeyDefence/events/OnPathChanged.java
+++ b/src/main/java/org/terasology/gooeyDefence/events/OnPathChanged.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.events;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.math.geom.Vector3i;
+
+import java.util.List;
+
+public class OnPathChanged implements Event {
+    private int pathId;
+    private List<Vector3i> newPath;
+
+    public OnPathChanged(int pathId, List<Vector3i> newPath) {
+        this.pathId = pathId;
+        this.newPath = newPath;
+    }
+
+    public List<Vector3i> getNewPath() {
+        return newPath;
+    }
+
+    public int getPathId() {
+        return pathId;
+    }
+}

--- a/src/main/java/org/terasology/gooeyDefence/events/RepathEnemyRequest.java
+++ b/src/main/java/org/terasology/gooeyDefence/events/RepathEnemyRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.events;
+
+import org.terasology.entitySystem.event.Event;
+
+public class RepathEnemyRequest implements Event {
+}

--- a/src/main/java/org/terasology/gooeyDefence/events/RepathEnemyRequest.java
+++ b/src/main/java/org/terasology/gooeyDefence/events/RepathEnemyRequest.java
@@ -17,5 +17,12 @@ package org.terasology.gooeyDefence.events;
 
 import org.terasology.entitySystem.event.Event;
 
+/**
+ * Event is sent when an enemy is no longer on an entrance path.
+ *
+ * Calls the {@link org.terasology.gooeyDefence.PathfindingSystem} to re-path this enemy towards the shrine
+ *
+ * @see org.terasology.gooeyDefence.components.enemies.CustomPathComponent
+ */
 public class RepathEnemyRequest implements Event {
 }

--- a/src/main/java/org/terasology/gooeyDefence/towerBlocks/emitters/SingleTargetEmitterSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/towerBlocks/emitters/SingleTargetEmitterSystem.java
@@ -22,7 +22,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.gooeyDefence.EnemyManager;
-import org.terasology.gooeyDefence.components.GooeyComponent;
+import org.terasology.gooeyDefence.components.enemies.PathComponent;
 import org.terasology.gooeyDefence.events.combat.DoSelectEnemies;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.registry.In;
@@ -50,9 +50,9 @@ public class SingleTargetEmitterSystem extends BaseComponentSystem {
                 locationComponent.getWorldPosition(),
                 emitterComponent.getRange());
         Optional<EntityRef> firstEnemy = targets.stream().min((first, second) -> {
-            GooeyComponent firstComponent = first.getComponent(GooeyComponent.class);
-            GooeyComponent secondComponent = second.getComponent(GooeyComponent.class);
-            return firstComponent.currentStep - secondComponent.currentStep;
+            PathComponent firstComponent = EnemyManager.getPathComponent(first);
+            PathComponent secondComponent = EnemyManager.getPathComponent(second);
+            return firstComponent.getStep() - secondComponent.getStep();
         });
         firstEnemy.ifPresent(event::addToList);
     }


### PR DESCRIPTION
Adds the ability for enemies to be re-pathed when the path they are following changes
This fixes #3

## Testing

To test this simply start up a world and spawn in a few enemies by interacting with any block (`E`).  
Then, place or remove a block that makes one of the paths change. The enemies will switch to the new path if they can, and if not use custom pathfinding to move to a different path.