### PR TITLE
Changes to allow enemies to climb

### DIFF
--- a/src/main/java/org/terasology/gooeyDefence/InWorldRenderer.java
+++ b/src/main/java/org/terasology/gooeyDefence/InWorldRenderer.java
@@ -61,6 +61,7 @@ public class InWorldRenderer extends BaseComponentSystem implements RenderSystem
         for (List<Vector3i> path : paths) {
             if (path != null) {
                 for (Vector3i pos : path) {
+                    pathBlockRenderer.renderMark2(pos);
                     pathBlockRenderer.renderMark2(Vector3i.up().add(pos));
                 }
             }

--- a/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/PathfindingSystem.java
@@ -132,13 +132,16 @@ public class PathfindingSystem extends BaseComponentSystem {
     private void calculatePath(Vector3i startPoint, BiConsumer<List<Vector3i>, Vector3i> callback) {
         JPSConfig config = new JPSConfig();
         /* Backwards to ensure that zero is at the field centre */
-        config.start = DefenceField.fieldCentre();
-        config.stop = startPoint;
+        config.start = startPoint;
+        config.stop = DefenceField.fieldCentre();
         config.maxDepth = DefenceField.outerRingSize() * 2;
         //TODO: Replace width and height with values from enemy.
         config.plugin = new EnemyWalkingPlugin(worldProvider, 0.5f, 0.5f);
-        config.maxTime = 4f;
-        pathfinderSystem.requestPath(config, callback::accept);
+        config.maxTime = 10f;
+        pathfinderSystem.requestPath(config, (path, end) -> {
+            Collections.reverse(path);
+            callback.accept(path, DefenceField.fieldCentre());
+        });
     }
 
     /**

--- a/src/main/java/org/terasology/gooeyDefence/pathfinding/EnemyWalkingPlugin.java
+++ b/src/main/java/org/terasology/gooeyDefence/pathfinding/EnemyWalkingPlugin.java
@@ -27,15 +27,22 @@ public class EnemyWalkingPlugin extends WalkingPlugin {
 
     @Override
     public boolean isReachable(Vector3i to, Vector3i from) {
-        /* If the height difference between the two is more than 1 block */
-        if (Math.abs(to.y - from.y) > 1) {
+
+        /* Check both positions are not the same */
+        if (to.equals(from)
+                /* We can go diagonally if it's horizontal */
+                || to.y == from.y && to.distanceSquared(from) > 2
+                /* We can only go directly up or down */
+                || to.y != from.y && to.distanceSquared(from) > 1
+                /* Check that at least one of the to or from are walkable */
+                || !(isWalkable(to) || isWalkable(from))) {
             return false;
         }
 
-        // check that all blocks passed through by this movement are penetrable
+        /* Check that all blocks passed through by this movement are penetrable */
         for (Vector3i occupiedBlock : getOccupiedRegionRelative()) {
 
-            // the start/stop for this block in the occupied region
+            /* The start/stop for this block in the occupied region */
             Vector3i occupiedBlockTo = new Vector3i(to).add(occupiedBlock);
             Vector3i occupiedBlockFrom = new Vector3i(from).add(occupiedBlock);
 
@@ -46,7 +53,6 @@ public class EnemyWalkingPlugin extends WalkingPlugin {
                 }
             }
         }
-
-        return isWalkable(to) || isWalkable(from);
+        return true;
     }
 }

--- a/src/main/java/org/terasology/gooeyDefence/pathfinding/EnemyWalkingPlugin.java
+++ b/src/main/java/org/terasology/gooeyDefence/pathfinding/EnemyWalkingPlugin.java
@@ -27,26 +27,27 @@ public class EnemyWalkingPlugin extends WalkingPlugin {
 
     @Override
     public boolean isReachable(Vector3i to, Vector3i from) {
+        return !to.equals(from)
+                && (isHorizontallyReachable(to, from) || isVerticallyReachable(to, from))
+                && isWalkable(to, from)
+                && areAllBlocksPenetrable(to, from);
+    }
 
-        /* Check both positions are not the same */
-        if (to.equals(from)
-                /* We can go diagonally if it's horizontal */
-                || to.y == from.y && to.distanceSquared(from) > 2
-                /* We can only go directly up or down */
-                || to.y != from.y && to.distanceSquared(from) > 1
-                /* Check that at least one of the to or from are walkable */
-                || !(isWalkable(to) || isWalkable(from))) {
-            return false;
-        }
-
-        /* Check that all blocks passed through by this movement are penetrable */
-        for (Vector3i occupiedBlock : getOccupiedRegionRelative()) {
+    /**
+     * Checks that all the blocks the enemy will pass through are penetrable.
+     *
+     * @param to   The ending position
+     * @param from The starting position
+     * @return True if all the blocks are penetrable.
+     */
+    private boolean areAllBlocksPenetrable(Vector3i to, Vector3i from) {
+        for (Vector3i relativePosition : getOccupiedRegionRelative()) {
 
             /* The start/stop for this block in the occupied region */
-            Vector3i occupiedBlockTo = new Vector3i(to).add(occupiedBlock);
-            Vector3i occupiedBlockFrom = new Vector3i(from).add(occupiedBlock);
+            Vector3i occupiedRegionStart = new Vector3i(to).add(relativePosition);
+            Vector3i occupiedRegionEnd = new Vector3i(from).add(relativePosition);
 
-            Region3i movementBounds = Region3i.createBounded(occupiedBlockTo, occupiedBlockFrom);
+            Region3i movementBounds = Region3i.createBounded(occupiedRegionStart, occupiedRegionEnd);
             for (Vector3i block : movementBounds) {
                 if (!world.getBlock(block).isPenetrable()) {
                     return false;
@@ -54,5 +55,52 @@ public class EnemyWalkingPlugin extends WalkingPlugin {
             }
         }
         return true;
+    }
+
+    /**
+     * When travelling horizontally, the enemy can travel along all 8 horizonatal directions.
+     * That is, the enemy can travel diagonally as well as cardinally.
+     *
+     * @param to   The ending position
+     * @param from The starting position
+     * @return True if the movement is horizontally possible.
+     */
+    private boolean isHorizontallyReachable(Vector3i to, Vector3i from) {
+        return isMovementHorizontal(to, from) && to.distanceSquared(from) <= 2;
+    }
+
+    /**
+     * When travelling vertically, the enemy can only go directly up or down.
+     * That is, they cannot travel diagonally
+     *
+     * @param to   The ending position
+     * @param from The starting position
+     * @return True if the movement is vertically possible.
+     */
+    private boolean isVerticallyReachable(Vector3i to, Vector3i from) {
+        return !isMovementHorizontal(to, from) && to.distanceSquared(from) <= 1;
+    }
+
+    /**
+     * Check if the movement is walkable.
+     * <p>
+     *
+     * @param to   The ending position
+     * @param from The starting position
+     * @return True if the the movement is walkable
+     */
+    private boolean isWalkable(Vector3i to, Vector3i from) {
+        return isWalkable(to) || isWalkable(from);
+    }
+
+    /**
+     * Checks if the movement is strictly horizontal
+     *
+     * @param to   The ending position
+     * @param from The starting position
+     * @return True if both positions are at the same height.
+     */
+    private boolean isMovementHorizontal(Vector3i to, Vector3i from) {
+        return to.y == from.y;
     }
 }

--- a/src/main/java/org/terasology/gooeyDefence/pathfinding/EnemyWalkingPlugin.java
+++ b/src/main/java/org/terasology/gooeyDefence/pathfinding/EnemyWalkingPlugin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.pathfinding;
+
+import org.terasology.flexiblepathfinding.plugins.basic.WalkingPlugin;
+import org.terasology.math.Region3i;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.world.WorldProvider;
+
+public class EnemyWalkingPlugin extends WalkingPlugin {
+    public EnemyWalkingPlugin(WorldProvider world, float width, float height) {
+        super(world, width, height);
+    }
+
+    @Override
+    public boolean isReachable(Vector3i to, Vector3i from) {
+        /* If the height difference between the two is more than 1 block */
+        if (Math.abs(to.y - from.y) > 1) {
+            return false;
+        }
+
+        // check that all blocks passed through by this movement are penetrable
+        for (Vector3i occupiedBlock : getOccupiedRegionRelative()) {
+
+            // the start/stop for this block in the occupied region
+            Vector3i occupiedBlockTo = new Vector3i(to).add(occupiedBlock);
+            Vector3i occupiedBlockFrom = new Vector3i(from).add(occupiedBlock);
+
+            Region3i movementBounds = Region3i.createBounded(occupiedBlockTo, occupiedBlockFrom);
+            for (Vector3i block : movementBounds) {
+                if (!world.getBlock(block).isPenetrable()) {
+                    return false;
+                }
+            }
+        }
+
+        return isWalkable(to) || isWalkable(from);
+    }
+}


### PR DESCRIPTION
Utilises a plugin to FlexiblePathfinding to allow enemies to travel vertically. The enemies can only travel up or down one block at a time.
Also includes a fix for an odd bug where calculating the path by starting at the shrine caused it to not correctly function.

## Testing

Test by simply loading any new world and activating it by interacting with any block (via `E`). The displayed path will travel over one block high obstacles.

Placing a two block high wall in the way will cause the path to go around it (Or over if it can find a one high block to use to get ontop of the wall)