### PR TITLE
Implement upgrading blocks

### DIFF
--- a/assets/prefabs/blocks/cores/Core1.prefab
+++ b/assets/prefabs/blocks/cores/Core1.prefab
@@ -1,7 +1,40 @@
 {
   "parent": "GooeyDefence:PlainBlock",
   "Core": {
-    "power": 10,
-    "attackSpeed": 500
+    "power": 10
+  },
+  "BlockUpgrades": {
+    "componentName": "Core",
+    "upgrades": [
+      {
+        "name": "Core Power",
+        "stages": [
+          {
+            "cost": 5,
+            "values": {
+              "power": 1
+            }
+          },
+          {
+            "cost": 5,
+            "values": {
+              "power": 2
+            }
+          },
+          {
+            "cost": 5,
+            "values": {
+              "power": 3
+            }
+          },
+          {
+            "cost": 5,
+            "values": {
+              "power": 4
+            }
+          }
+        ]
+      }
+    ]
   }
 }

--- a/src/main/java/org/terasology/gooeyDefence/TowerBuildSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/TowerBuildSystem.java
@@ -134,11 +134,10 @@ public class TowerBuildSystem extends BaseComponentSystem {
             default:
                 /* Pick a tower to merge all the others into */
                 EntityRef targetTower = towers.iterator().next();
-                addToTower(targetTower, blockEntity);
-                towers.remove(targetTower);
-
                 Set<EntityRef> oldBlocks = getAllFrom(targetTower);
 
+                addToTower(targetTower, blockEntity);
+                towers.remove(targetTower);
                 mergeTowers(targetTower, towers);
 
                 Set<EntityRef> newBlocks = getAllFrom(targetTower);

--- a/src/main/java/org/terasology/gooeyDefence/TowerManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/TowerManager.java
@@ -61,7 +61,7 @@ public class TowerManager extends BaseComponentSystem {
      * @see PeriodicActionTriggeredEvent
      */
     private static String buildEventId(EntityRef tower, EntityRef targeter) {
-        return "towerDefence" + tower.getId() + "|" + targeter.getId();
+        return "towerDefence|" + targeter.getId();
     }
 
     /**
@@ -73,7 +73,7 @@ public class TowerManager extends BaseComponentSystem {
      * @see PeriodicActionTriggeredEvent
      */
     private static boolean isEventIdCorrect(EntityRef tower, String eventId) {
-        return eventId.startsWith("towerDefence" + tower.getId());
+        return eventId.startsWith("towerDefence");
     }
 
     /**

--- a/src/main/java/org/terasology/gooeyDefence/upgrading/BlockUpgradesComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/upgrading/BlockUpgradesComponent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.upgrading;
+
+import org.terasology.entitySystem.Component;
+
+import java.util.List;
+
+/**
+ * Contains all the information related tot he upgrades possible for this block
+ *
+ * @see UpgradeList
+ * @see UpgradingSystem
+ */
+public class BlockUpgradesComponent implements Component {
+    /**
+     * The component the upgrades will apply to.
+     * Should be the name without the <code>Component</code> ending.
+     * Eg, <code>"SingleTargeterComponent"</code> should be <code>"SingleTargeter</code>
+     */
+    private String componentName;
+    /**
+     * All of the upgrade paths applicable
+     */
+    private List<UpgradeList> upgrades;
+
+    public String getComponentName() {
+        return componentName;
+    }
+
+    public List<UpgradeList> getUpgrades() {
+        return upgrades;
+    }
+}

--- a/src/main/java/org/terasology/gooeyDefence/upgrading/UpgradeInfo.java
+++ b/src/main/java/org/terasology/gooeyDefence/upgrading/UpgradeInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.upgrading;
+
+import org.terasology.reflection.MappedContainer;
+
+import java.util.Map;
+
+/**
+ * Represents a single upgrade
+ *
+ * @see UpgradeList
+ * @see BlockUpgradesComponent
+ */
+@MappedContainer
+public class UpgradeInfo {
+    /**
+     * How much the upgrade will cost
+     */
+    private int cost;
+    /**
+     * A mapping between the fields to set, and how much to change them by.
+     * Eg, <code>"power": 5</code> will try to increase the field <code>power</code> by 5
+     */
+    private Map<String, Number> values;
+
+    public int getCost() {
+        return cost;
+    }
+
+    public Map<String, Number> getValues() {
+        return values;
+    }
+}

--- a/src/main/java/org/terasology/gooeyDefence/upgrading/UpgradeList.java
+++ b/src/main/java/org/terasology/gooeyDefence/upgrading/UpgradeList.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.upgrading;
+
+import org.terasology.reflection.MappedContainer;
+
+import java.util.List;
+
+/**
+ * Represents a sequence of upgrades.
+ *
+ * @see UpgradeInfo
+ * @see BlockUpgradesComponent
+ */
+@MappedContainer
+public class UpgradeList {
+    /**
+     * The name of this sequence of upgrades
+     */
+    private String upgradeName;
+    /**
+     * The list of upgrade stages.
+     * Order is important, and should be ordered such that 0 is first.
+     */
+    private List<UpgradeInfo> stages;
+
+    public List<UpgradeInfo> getStages() {
+        return stages;
+    }
+
+    public String getUpgradeName() {
+        return upgradeName;
+    }
+
+}

--- a/src/main/java/org/terasology/gooeyDefence/upgrading/UpgradingSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/upgrading/UpgradingSystem.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.upgrading;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.metadata.ComponentFieldMetadata;
+import org.terasology.entitySystem.metadata.ComponentLibrary;
+import org.terasology.entitySystem.metadata.ComponentMetadata;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.common.ActivateEvent;
+import org.terasology.registry.In;
+import org.terasology.registry.Share;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handles applying an upgrade to a component
+ */
+@Share(UpgradingSystem.class)
+@RegisterSystem
+public class UpgradingSystem extends BaseComponentSystem {
+    private static final Logger logger = LoggerFactory.getLogger(UpgradingSystem.class);
+    @In
+    private EntityManager entityManager;
+    private ComponentLibrary componentLibrary;
+
+    @Override
+    public void postBegin() {
+        componentLibrary = entityManager.getComponentLibrary();
+    }
+
+    /**
+     * Test handler.
+     * <p>
+     * Filters on {@link BlockUpgradesComponent}
+     *
+     * @see ActivateEvent
+     */
+    @ReceiveEvent
+    public void onActivate(ActivateEvent event, EntityRef entity, BlockUpgradesComponent upgraderComponent) {
+        for (UpgradeList upgradeList : upgraderComponent.getUpgrades()) {
+            /* Print out the name and apply the upgrade */
+            logger.info("Applying upgrade " + upgradeList.getUpgradeName());
+            List<UpgradeInfo> stages = upgradeList.getStages();
+            if (!stages.isEmpty()) {
+                applyUpgrade(entity, stages.remove(0));
+            }
+        }
+        logger.info(entity.toFullDescription());
+    }
+
+    /**
+     * Applies a given upgrade to the entity.
+     *
+     * @param entity  The entity to upgrade
+     * @param upgrade The upgrade to apply
+     * @see UpgradeInfo
+     */
+    public void applyUpgrade(EntityRef entity, UpgradeInfo upgrade) {
+        /* Get needed data */
+        BlockUpgradesComponent upgradesComponent = entity.getComponent(BlockUpgradesComponent.class);
+        ComponentMetadata<?> componentMeta = componentLibrary.resolve(upgradesComponent.getComponentName());
+        Class<? extends Component> componentClass = componentMeta.getType();
+        Component component = entity.getComponent(componentClass);
+
+        /* Apply upgrade for each field */
+        for (Map.Entry<String, Number> entry : upgrade.getValues().entrySet()) {
+            ComponentFieldMetadata<?, ?> fieldMeta = componentMeta.getField(entry.getKey());
+            setField(fieldMeta, component, entry.getValue());
+        }
+    }
+
+    /**
+     * Sets a Number field to the given value.
+     * Requires the field to be of a primitive number type.
+     *
+     * @param field     The field to set
+     * @param component The component containing the field to set
+     * @param value     The value to set the field to
+     */
+    private void setField(ComponentFieldMetadata field, Component component, Number value) {
+        switch (field.getType().getSimpleName()) {
+            case "int":
+                field.setValue(component, (int) field.getValue(component) + value.intValue());
+                break;
+            case "double":
+                field.setValue(component, (double) field.getValue(component) + value.doubleValue());
+                break;
+            case "float":
+                field.setValue(component, (float) field.getValue(component) + value.floatValue());
+                break;
+            case "long":
+                field.setValue(component, (long) field.getValue(component) + value.longValue());
+                break;
+            case "short":
+                field.setValue(component, (short) field.getValue(component) + value.shortValue());
+                break;
+            case "byte":
+                field.setValue(component, (byte) field.getValue(component) + value.byteValue());
+                break;
+            default:
+                //TODO: work out what to throw here
+                throw new Error("Can't set field of type: "
+                        + field.getField().getGenericType().getTypeName()
+                        + ". Type must be a Number primitive");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the abilityto upgrade blocks.

Upgrade information is given by the `BlockUpgradesComponent` which includes multiple upgrade "paths" and the component to upgrade.  
An example is given on the prefab `Core1`