### PR TITLE
Activate screen

### DIFF
--- a/assets/skins/activateScreenSkin.skin
+++ b/assets/skins/activateScreenSkin.skin
@@ -1,0 +1,9 @@
+{
+  "inherit": "default",
+  "families": {
+    "title": {
+      "font": "NotoSans-Regular-Large",
+      "text-color": "F0F0F0FF"
+    }
+  }
+}

--- a/assets/ui/activateGameScreen.ui
+++ b/assets/ui/activateGameScreen.ui
@@ -1,0 +1,120 @@
+{
+  "type": "ActivateGameScreen",
+  "skin": "activateScreenSkin",
+  "contents": {
+    "type": "RelativeLayout",
+    "id": "outerLayout",
+    "contents": [
+      {
+        "type": "UIBox",
+        "id": "outerBox",
+        "layoutInfo": {
+          "use-content-height": false,
+          "use-content-width": false,
+          "position-top": {
+            "offset": 64
+          },
+          "position-left": {
+            "offset": 128
+          },
+          "position-right": {
+            "offset": 128
+          },
+          "position-bottom": {
+            "offset": 64
+          }
+        },
+        "content": {
+          "type": "RelativeLayout",
+          "id": "innerLayout",
+          "contents": [
+            {
+              "type": "UILabel",
+              "id": "titleLabel",
+              "family": "title",
+              "text": "Welcome to Gooey's Defence",
+              "layoutInfo": {
+                "use-content-height": true,
+                "use-content-width": true,
+                "position-top": {},
+                "position-horizontal-center": {}
+              }
+            },
+            {
+              "type": "RelativeLayout",
+              "id": "newGameLayout",
+              "layoutInfo": {
+                "use-content-height": false,
+                "use-content-width": false,
+                "position-top": {
+                  "offset": 16,
+                  "target": "BOTTOM",
+                  "widget": "titleLabel"
+                },
+                "position-left": {
+                  "offset": 32
+                },
+                "position-right": {
+                  "offset": 32
+                },
+                "position-bottom": {
+                  "offset": 16,
+                  "target": "TOP",
+                  "widget": "beginButton"
+                }
+              },
+              "contents": [
+                {
+                  "type": "UILabel",
+                  "id": "newGameInformationLabel",
+                  "text": "Gooey's Defence is a tower defence module where you have to defend a central shrine from multiple waves of enemies. It is currently under development so play at your own risk.\n For detailed instructions on how to play, please see the readme on the github repo.",
+                  "layoutInfo": {
+                    "use-content-height": false,
+                    "use-content-width": false,
+                    "position-top": {},
+                    "position-horizontal-centre": {}
+                  }
+                }
+              ]
+            },
+            {
+              "type": "RelativeLayout",
+              "id": "resumeGameLayout",
+              "layoutInfo": {
+                "use-content-height": false,
+                "use-content-width": false,
+                "position-top": {
+                  "offset": 16,
+                  "target": "BOTTOM",
+                  "widget": "titleLabel"
+                },
+                "position-left": {
+                  "offset": 32
+                },
+                "position-right": {
+                  "offset": 32
+                },
+                "position-bottom": {
+                  "offset": 16,
+                  "target": "TOP",
+                  "widget": "beginButton"
+                }
+              }
+            },
+            {
+              "type": "UIButton",
+              "id": "beginButton",
+              "text": "Begin",
+              "layoutInfo": {
+                "use-content-height": true,
+                "use-content-width": true,
+                "position-bottom": {},
+                "position-horizontal-center": {}
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/assets/ui/activateGameScreen.ui
+++ b/assets/ui/activateGameScreen.ui
@@ -99,7 +99,20 @@
                   "target": "TOP",
                   "widget": "beginButton"
                 }
-              }
+              },
+              "contents":[
+                {
+                  "type": "UILabel",
+                  "id": "newGameInformationLabel",
+                  "text": "To resume your game, exit this screen or press the begin button.\nBe warned, the game will resume from exactly where you left it. This may include being in the middle of a wave",
+                  "layoutInfo": {
+                    "use-content-height": false,
+                    "use-content-width": false,
+                    "position-top": {},
+                    "position-horizontal-centre": {}
+                  }
+                }
+              ]
             },
             {
               "type": "UIButton",

--- a/src/main/java/org/terasology/gooeyDefence/components/NewGameFlagComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/components/NewGameFlagComponent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.components;
+
+import org.terasology.entitySystem.Component;
+
+public class NewGameFlagComponent implements Component {
+}

--- a/src/main/java/org/terasology/gooeyDefence/ui/activation/ActivateGameScreen.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/activation/ActivateGameScreen.java
@@ -16,6 +16,7 @@
 package org.terasology.gooeyDefence.ui.activation;
 
 import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.layouts.relative.RelativeLayout;
 import org.terasology.rendering.nui.widgets.ActivateEventListener;
 import org.terasology.rendering.nui.widgets.UIButton;
 
@@ -23,14 +24,24 @@ public class ActivateGameScreen extends CoreScreenLayer {
     private ActivateEventListener listener;
 
     private UIButton beginButton;
+    private RelativeLayout newGameLayout;
+    private RelativeLayout resumeGameLayout;
 
     @Override
     public void initialise() {
         beginButton = find("beginButton", UIButton.class);
 
+        newGameLayout = find("newGameLayout", RelativeLayout.class);
+        resumeGameLayout = find("resumeGameLayout", RelativeLayout.class);
     }
 
     public void subscribeToBegin(ActivateEventListener listener) {
         beginButton.subscribe(listener);
     }
+
+    public void setNewGame(boolean isNewGame) {
+        newGameLayout.setVisible(isNewGame);
+        resumeGameLayout.setVisible(!isNewGame);
+    }
+
 }

--- a/src/main/java/org/terasology/gooeyDefence/ui/activation/ActivateGameScreen.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/activation/ActivateGameScreen.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.ui.activation;
+
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.widgets.ActivateEventListener;
+import org.terasology.rendering.nui.widgets.UIButton;
+
+public class ActivateGameScreen extends CoreScreenLayer {
+    private ActivateEventListener listener;
+
+    private UIButton beginButton;
+
+    @Override
+    public void initialise() {
+        beginButton = find("beginButton", UIButton.class);
+
+    }
+
+    public void subscribeToBegin(ActivateEventListener listener) {
+        beginButton.subscribe(listener);
+    }
+}

--- a/src/main/java/org/terasology/gooeyDefence/ui/activation/ActivateScreenSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/activation/ActivateScreenSystem.java
@@ -20,6 +20,8 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.gooeyDefence.DefenceWorldManager;
+import org.terasology.gooeyDefence.components.NewGameFlagComponent;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.ScreenLayerClosedEvent;
@@ -32,6 +34,8 @@ public class ActivateScreenSystem extends BaseComponentSystem {
 
     @In
     private NUIManager nuiManager;
+    @In
+    private LocalPlayer localPlayer;
 
     @Override
     public void postBegin() {
@@ -46,6 +50,8 @@ public class ActivateScreenSystem extends BaseComponentSystem {
         if (event.getClosedScreenUri().getResourceName().toString().equals("loadingScreen")) {
             ActivateGameScreen screen = nuiManager.pushScreen("activateGameScreen", ActivateGameScreen.class);
             screen.subscribeToBegin(widget -> nuiManager.closeScreen(screen));
+            screen.setNewGame(!localPlayer.getCharacterEntity().hasComponent(NewGameFlagComponent.class));
+            localPlayer.getCharacterEntity().addOrSaveComponent(new NewGameFlagComponent());
         } else if (event.getClosedScreenUri().getResourceName().toString().equals("activateGameScreen")) {
             DefenceWorldManager.activateWorld();
         }

--- a/src/main/java/org/terasology/gooeyDefence/ui/activation/ActivateScreenSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/activation/ActivateScreenSystem.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.ui.activation;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.gooeyDefence.DefenceWorldManager;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.ScreenLayerClosedEvent;
+
+/**
+ *
+ */
+@RegisterSystem
+public class ActivateScreenSystem extends BaseComponentSystem {
+
+    @In
+    private NUIManager nuiManager;
+
+    @Override
+    public void postBegin() {
+        super.postBegin();
+    }
+
+    /**
+     * @see ScreenLayerClosedEvent
+     */
+    @ReceiveEvent
+    public void onPlayerSpawned(ScreenLayerClosedEvent event, EntityRef entity) {
+        if (event.getClosedScreenUri().getResourceName().toString().equals("loadingScreen")) {
+            ActivateGameScreen screen = nuiManager.pushScreen("activateGameScreen", ActivateGameScreen.class);
+            screen.subscribeToBegin(widget -> nuiManager.closeScreen(screen));
+        } else if (event.getClosedScreenUri().getResourceName().toString().equals("activateGameScreen")) {
+            DefenceWorldManager.activateWorld();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds in screen to be displayed once the game is loaded.
This screen then allows the user to begin the game and serves as a buffer between loading the game from main menu and the game starting.

To test, simply create a new world and verify the screen appears and activates the world when closed. Then exit the game and reload it, to verify that the text has changed but it still activates when closed