### PR TITLE
Add screen and handling for game over

### DIFF
--- a/assets/prefabs/enemies/BasicEnemy.prefab
+++ b/assets/prefabs/enemies/BasicEnemy.prefab
@@ -28,6 +28,7 @@
     ]
   },
   "Gooey": {
+    "damage": 3
   },
   "Movement": {
     "speed": 3

--- a/assets/prefabs/enemies/FastEnemy.prefab
+++ b/assets/prefabs/enemies/FastEnemy.prefab
@@ -28,6 +28,7 @@
     ]
   },
   "Gooey": {
+    "damage": 1
   },
   "Movement": {
     "speed": 6

--- a/assets/prefabs/enemies/StrongEnemy.prefab
+++ b/assets/prefabs/enemies/StrongEnemy.prefab
@@ -28,6 +28,7 @@
     ]
   },
   "Gooey": {
+    "damage": 6
   },
   "Movement": {
     "speed": 1

--- a/assets/prefabs/world/Shrine.prefab
+++ b/assets/prefabs/world/Shrine.prefab
@@ -1,7 +1,7 @@
 {
   "alwaysRelevant": true,
   "Shrine": {},
-  "Health": {
+  "GooeyDefence:Health": {
     "health": 100
   }
 }

--- a/overrides/Engine/ui/ingame/deathScreen.ui
+++ b/overrides/Engine/ui/ingame/deathScreen.ui
@@ -1,0 +1,56 @@
+{
+  "type": "deathScreen",
+  "skin": "deathScreen",
+  "contents": {
+    "type": "relativeLayout",
+    "contents": [
+      {
+        "type": "ColumnLayout",
+        "verticalSpacing": 8,
+        "layoutInfo": {
+          "use-content-width": true,
+          "use-content-height": true,
+          "position-horizontal-center": {},
+          "position-vertical-center": {}
+        },
+        "contents": [
+          {
+            "type": "UILabel",
+            "text": "${engine:menu#death-screen-title}"
+          },
+          {
+            "type": "UILabel",
+            "id": "deathDetails"
+          },
+          {
+            "type": "UISpace",
+            "size": [
+              1,
+              16
+            ]
+          },
+          {
+            "type": "UIButton",
+            "text": "${engine:menu#respawn}",
+            "id": "respawn"
+          },
+          {
+            "type": "UIButton",
+            "text": "${engine:menu#game-settings}",
+            "id": "settings"
+          },
+          {
+            "type": "UIButton",
+            "text": "${engine:menu#return-main-menu}",
+            "id": "mainMenu"
+          },
+          {
+            "type": "UIButton",
+            "text": "${engine:menu#exit-game}",
+            "id": "exitGame"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/overrides/Engine/ui/ingame/deathScreen.ui
+++ b/overrides/Engine/ui/ingame/deathScreen.ui
@@ -7,6 +7,8 @@
       {
         "type": "ColumnLayout",
         "verticalSpacing": 8,
+        "autoSizeColumns": false,
+        "fillVerticalSpace": false,
         "layoutInfo": {
           "use-content-width": true,
           "use-content-height": true,
@@ -16,11 +18,11 @@
         "contents": [
           {
             "type": "UILabel",
-            "text": "${engine:menu#death-screen-title}"
+            "text": "Game Over"
           },
           {
             "type": "UILabel",
-            "id": "deathDetails"
+            "text": "Unfortunately the shrine was eventually overrun and destroyed."
           },
           {
             "type": "UISpace",
@@ -31,8 +33,8 @@
           },
           {
             "type": "UIButton",
-            "text": "${engine:menu#respawn}",
-            "id": "respawn"
+            "text": "Retry",
+            "id": "retry"
           },
           {
             "type": "UIButton",
@@ -50,6 +52,30 @@
             "id": "exitGame"
           }
         ]
+      },
+      {
+        "type": "UILabel",
+        "id": "deathDetails",
+        "visible": false,
+        "layoutInfo": {
+          "use-content-height": false,
+          "use-content-width": false,
+          "position-top": {},
+          "position-left": {}
+        }
+      },
+      {
+        "type": "UIButton",
+        "text": "${engine:menu#respawn}",
+        "id": "respawn",
+        "enabled": false,
+        "visible": false,
+        "layoutInfo": {
+          "use-content-height": false,
+          "use-content-width": false,
+          "position-top": {},
+          "position-left": {}
+        }
       }
     ]
   }

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -154,7 +154,7 @@ public class EnemyManager extends BaseComponentSystem {
         event.consume();
         PathComponent pathComponent = DefenceField.getComponentExtending(entity, PathComponent.class);
         if (pathComponent.atEnd()) {
-            entity.send(new DamageEntityEvent(gooeyComponent.damage));
+            DefenceField.getShrineEntity().send(new DamageEntityEvent(gooeyComponent.damage));
             destroyEnemy(entity);
         } else {
             pathComponent.nextStep();

--- a/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/EnemyManager.java
@@ -28,6 +28,7 @@ import org.terasology.gooeyDefence.components.enemies.GooeyComponent;
 import org.terasology.gooeyDefence.economy.ValueComponent;
 import org.terasology.gooeyDefence.events.OnEntrancePathChanged;
 import org.terasology.gooeyDefence.events.OnFieldActivated;
+import org.terasology.gooeyDefence.events.OnFieldReset;
 import org.terasology.gooeyDefence.events.health.DamageEntityEvent;
 import org.terasology.gooeyDefence.events.health.EntityDeathEvent;
 import org.terasology.gooeyDefence.movement.PathfindingManager;
@@ -66,6 +67,19 @@ public class EnemyManager extends BaseComponentSystem {
     private PathfindingManager pathfindingManager;
     @In
     private DelayManager delayManager;
+
+    /**
+     * Removes all the existing enemies.
+     * <p>
+     * Sent when the field is to be reset
+     *
+     * @see OnFieldReset
+     */
+    @ReceiveEvent
+    public void onFieldReset(OnFieldReset event, EntityRef entity) {
+        enemies.forEach(EntityRef::destroy);
+        enemies.clear();
+    }
 
     /**
      * Called when the field is activated.

--- a/src/main/java/org/terasology/gooeyDefence/events/CallbackEvent.java
+++ b/src/main/java/org/terasology/gooeyDefence/events/CallbackEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,32 @@
  */
 package org.terasology.gooeyDefence.events;
 
-import org.terasology.entitySystem.event.Event;
+public abstract class CallbackEvent {
+    private Runnable callback;
+    private int tasks;
 
-/**
- * Event sent to initialise the field after a new game or a save has been loaded.
- *
- * @see CallbackEvent
- */
-public class OnFieldActivated extends CallbackEvent implements Event {
-    public OnFieldActivated(Runnable runnable) {
-        super(runnable);
+    public CallbackEvent() {
+
+    }
+
+    public CallbackEvent(Runnable callback) {
+        this.callback = callback;
+    }
+
+    /**
+     * Record that a new task is underway
+     */
+    public void beginTask() {
+        tasks++;
+    }
+
+    /**
+     * Record that a task has finished. If all tasks are over then run the callback.
+     */
+    public void finishTask() {
+        tasks--;
+        if (tasks <= 0) {
+            callback.run();
+        }
     }
 }

--- a/src/main/java/org/terasology/gooeyDefence/events/OnFieldReset.java
+++ b/src/main/java/org/terasology/gooeyDefence/events/OnFieldReset.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.gooeyDefence.events;
 
+import org.terasology.entitySystem.event.Event;
 import org.terasology.gooeyDefence.ui.DeathScreenSystem;
 
 /**
@@ -22,10 +23,10 @@ import org.terasology.gooeyDefence.ui.DeathScreenSystem;
  * Calls on systems to reset their state to new.
  *
  * @see DeathScreenSystem
- * @see OnFieldActivated
+ * @see CallbackEvent
  */
-public class OnFieldReset extends OnFieldActivated {
-    public OnFieldReset(Runnable callback) {
-        super(callback);
+public class OnFieldReset extends CallbackEvent implements Event {
+    public OnFieldReset(Runnable runnable) {
+        super(runnable);
     }
 }

--- a/src/main/java/org/terasology/gooeyDefence/events/OnFieldReset.java
+++ b/src/main/java/org/terasology/gooeyDefence/events/OnFieldReset.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.events;
+
+import org.terasology.entitySystem.event.Event;
+
+public class OnFieldReset implements Event {
+}

--- a/src/main/java/org/terasology/gooeyDefence/events/OnFieldReset.java
+++ b/src/main/java/org/terasology/gooeyDefence/events/OnFieldReset.java
@@ -15,7 +15,17 @@
  */
 package org.terasology.gooeyDefence.events;
 
-import org.terasology.entitySystem.event.Event;
+import org.terasology.gooeyDefence.ui.DeathScreenSystem;
 
-public class OnFieldReset implements Event {
+/**
+ * Event sent when the reset option is chosen.
+ * Calls on systems to reset their state to new.
+ *
+ * @see DeathScreenSystem
+ * @see OnFieldActivated
+ */
+public class OnFieldReset extends OnFieldActivated {
+    public OnFieldReset(Runnable callback) {
+        super(callback);
+    }
 }

--- a/src/main/java/org/terasology/gooeyDefence/health/HealthSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/health/HealthSystem.java
@@ -16,9 +16,11 @@
 package org.terasology.gooeyDefence.health;
 
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.gooeyDefence.events.OnFieldActivated;
 import org.terasology.gooeyDefence.events.health.DamageEntityEvent;
 import org.terasology.gooeyDefence.events.health.EntityDeathEvent;
 
@@ -30,9 +32,12 @@ import org.terasology.gooeyDefence.events.health.EntityDeathEvent;
 @RegisterSystem
 public class HealthSystem extends BaseComponentSystem {
 
+
     /**
      * Deals damage to an entity.
      * If the entity's health reaches zero it sends a destruction event to be handled
+     * <p>
+     * Filters on {@link HealthComponent}
      *
      * @see DamageEntityEvent
      */
@@ -40,6 +45,23 @@ public class HealthSystem extends BaseComponentSystem {
     public void onDamageEntity(DamageEntityEvent event, EntityRef entity, HealthComponent component) {
         component.dealDamage(event.getDamage());
         if (component.getHealth() == 0) {
+            entity.send(new EntityDeathEvent());
+        }
+    }
+
+
+    /**
+     * Handles the case where a game is loaded from a save where the shrine has been killed.
+     * <p>
+     * Sent when the field is activated.
+     * Filters on {@link HealthComponent}
+     * Has priority {@link EventPriority#PRIORITY_LOW}
+     *
+     * @see OnFieldActivated
+     */
+    @ReceiveEvent(priority = EventPriority.PRIORITY_LOW)
+    public void onFieldActivated(OnFieldActivated event, EntityRef entity, HealthComponent component) {
+        if (component.getHealth() <= 0) {
             entity.send(new EntityDeathEvent());
         }
     }

--- a/src/main/java/org/terasology/gooeyDefence/movement/PathfindingManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/movement/PathfindingManager.java
@@ -18,14 +18,16 @@ package org.terasology.gooeyDefence.movement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.flexiblepathfinding.JPSConfig;
 import org.terasology.flexiblepathfinding.PathfinderSystem;
 import org.terasology.gooeyDefence.DefenceField;
-import org.terasology.gooeyDefence.events.OnFieldActivated;
 import org.terasology.gooeyDefence.events.OnEntrancePathChanged;
+import org.terasology.gooeyDefence.events.OnFieldActivated;
+import org.terasology.gooeyDefence.events.OnFieldReset;
 import org.terasology.gooeyDefence.movement.components.BlankPathComponent;
 import org.terasology.gooeyDefence.movement.components.CustomPathComponent;
 import org.terasology.gooeyDefence.movement.events.RepathEnemyRequest;
@@ -64,10 +66,30 @@ public class PathfindingManager extends BaseComponentSystem {
 
 
     /**
-     * Called to initialise the field.
+     * Begins the pathfinding calculations.
+     * <p>
+     * Called when the field is activated
+     *
+     * @see OnFieldActivated
      */
     @ReceiveEvent
     public void onFieldActivated(OnFieldActivated event, EntityRef entity) {
+        for (int id = 0; id < DefenceField.entranceCount(); id++) {
+            event.beginTask();
+            calculatePath(id, event::finishTask);
+        }
+    }
+
+    /**
+     * Begins the pathfinding calculations for the new world.
+     * <p>
+     * Called when the field is reset
+     * Has priority {@link EventPriority#PRIORITY_LOW}
+     *
+     * @see OnFieldReset
+     */
+    @ReceiveEvent(priority = EventPriority.PRIORITY_LOW)
+    public void onFieldReset(OnFieldReset event, EntityRef entity) {
         for (int id = 0; id < DefenceField.entranceCount(); id++) {
             event.beginTask();
             calculatePath(id, event::finishTask);

--- a/src/main/java/org/terasology/gooeyDefence/movement/PathfindingManager.java
+++ b/src/main/java/org/terasology/gooeyDefence/movement/PathfindingManager.java
@@ -18,7 +18,6 @@ package org.terasology.gooeyDefence.movement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -27,7 +26,6 @@ import org.terasology.flexiblepathfinding.PathfinderSystem;
 import org.terasology.gooeyDefence.DefenceField;
 import org.terasology.gooeyDefence.events.OnEntrancePathChanged;
 import org.terasology.gooeyDefence.events.OnFieldActivated;
-import org.terasology.gooeyDefence.events.OnFieldReset;
 import org.terasology.gooeyDefence.movement.components.BlankPathComponent;
 import org.terasology.gooeyDefence.movement.components.CustomPathComponent;
 import org.terasology.gooeyDefence.movement.events.RepathEnemyRequest;
@@ -74,22 +72,6 @@ public class PathfindingManager extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onFieldActivated(OnFieldActivated event, EntityRef entity) {
-        for (int id = 0; id < DefenceField.entranceCount(); id++) {
-            event.beginTask();
-            calculatePath(id, event::finishTask);
-        }
-    }
-
-    /**
-     * Begins the pathfinding calculations for the new world.
-     * <p>
-     * Called when the field is reset
-     * Has priority {@link EventPriority#PRIORITY_LOW}
-     *
-     * @see OnFieldReset
-     */
-    @ReceiveEvent(priority = EventPriority.PRIORITY_LOW)
-    public void onFieldReset(OnFieldReset event, EntityRef entity) {
         for (int id = 0; id < DefenceField.entranceCount(); id++) {
             event.beginTask();
             calculatePath(id, event::finishTask);

--- a/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
@@ -60,9 +60,19 @@ public class DeathScreenSystem extends BaseComponentSystem {
      * Triggers the resetting of the field.
      */
     private void triggerReset() {
+        OnFieldReset event = new OnFieldReset(this::finishReset);
+        event.beginTask();
+        DefenceField.getShrineEntity().send(event);
+        event.finishTask();
+    }
+
+    /**
+     * Called when the systems have finished resetting.
+     * Un-pauses the game and closes the screen
+     */
+    private void finishReset() {
         time.setPaused(false);
         nuiManager.closeScreen("Engine:DeathScreen");
-        DefenceField.getShrineEntity().send(new OnFieldReset());
     }
 
 }

--- a/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
@@ -19,7 +19,9 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.gooeyDefence.DefenceField;
 import org.terasology.gooeyDefence.components.ShrineComponent;
+import org.terasology.gooeyDefence.events.OnFieldReset;
 import org.terasology.gooeyDefence.events.health.EntityDeathEvent;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
@@ -31,10 +33,8 @@ import org.terasology.rendering.nui.layers.ingame.DeathScreen;
  */
 @RegisterSystem
 public class DeathScreenSystem extends BaseComponentSystem {
-
     @In
     private NUIManager nuiManager;
-
 
     /**
      * Used to display the death screen, and apply modifications to it.
@@ -48,14 +48,16 @@ public class DeathScreenSystem extends BaseComponentSystem {
     public void onEntityDeath(EntityDeathEvent event, EntityRef entity) {
         if (!nuiManager.isOpen("Engine:DeathScreen")) {
             DeathScreen deathScreen = nuiManager.pushScreen("Engine:DeathScreen", DeathScreen.class);
-            WidgetUtil.trySubscribe(deathScreen, "retry", widget -> {
-                triggerReset();
-            });
+            WidgetUtil.trySubscribe(deathScreen, "retry", widget -> triggerReset());
         }
     }
 
+    /**
+     * Triggers the resetting of the field.
+     */
     private void triggerReset() {
         nuiManager.closeScreen("Engine:DeathScreen");
+        DefenceField.getShrineEntity().send(new OnFieldReset());
     }
 
 }

--- a/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.gooeyDefence.ui;
 
+import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -35,6 +36,8 @@ import org.terasology.rendering.nui.layers.ingame.DeathScreen;
 public class DeathScreenSystem extends BaseComponentSystem {
     @In
     private NUIManager nuiManager;
+    @In
+    private Time time;
 
     /**
      * Used to display the death screen, and apply modifications to it.
@@ -47,6 +50,7 @@ public class DeathScreenSystem extends BaseComponentSystem {
     @ReceiveEvent(components = ShrineComponent.class)
     public void onEntityDeath(EntityDeathEvent event, EntityRef entity) {
         if (!nuiManager.isOpen("Engine:DeathScreen")) {
+            time.setPaused(true);
             DeathScreen deathScreen = nuiManager.pushScreen("Engine:DeathScreen", DeathScreen.class);
             WidgetUtil.trySubscribe(deathScreen, "retry", widget -> triggerReset());
         }
@@ -56,6 +60,7 @@ public class DeathScreenSystem extends BaseComponentSystem {
      * Triggers the resetting of the field.
      */
     private void triggerReset() {
+        time.setPaused(false);
         nuiManager.closeScreen("Engine:DeathScreen");
         DefenceField.getShrineEntity().send(new OnFieldReset());
     }

--- a/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
@@ -22,6 +22,7 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.gooeyDefence.DefenceField;
 import org.terasology.gooeyDefence.components.ShrineComponent;
+import org.terasology.gooeyDefence.events.OnFieldActivated;
 import org.terasology.gooeyDefence.events.OnFieldReset;
 import org.terasology.gooeyDefence.events.health.EntityDeathEvent;
 import org.terasology.registry.In;
@@ -60,14 +61,24 @@ public class DeathScreenSystem extends BaseComponentSystem {
      * Triggers the resetting of the field.
      */
     private void triggerReset() {
-        OnFieldReset event = new OnFieldReset(this::finishReset);
+        OnFieldReset event = new OnFieldReset(this::doActivation);
         event.beginTask();
         DefenceField.getShrineEntity().send(event);
         event.finishTask();
     }
 
     /**
-     * Called when the systems have finished resetting.
+     * Triggers the activation of the required game systems.
+     */
+    private void doActivation() {
+        OnFieldActivated activateEvent = new OnFieldActivated(this::finishReset);
+        activateEvent.beginTask();
+        DefenceField.getShrineEntity().send(activateEvent);
+        activateEvent.finishTask();
+    }
+
+    /**
+     * Called when the systems have finished resetting & activating.
      * Un-pauses the game and closes the screen
      */
     private void finishReset() {

--- a/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.gooeyDefence.ui;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.gooeyDefence.components.ShrineComponent;
+import org.terasology.gooeyDefence.events.health.EntityDeathEvent;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.layers.ingame.DeathScreen;
+import org.terasology.rendering.nui.widgets.UIButton;
+import org.terasology.rendering.nui.widgets.UILabel;
+
+/**
+ * Handles overwriting the death screen to allow
+ */
+@RegisterSystem
+public class DeathScreenSystem extends BaseComponentSystem {
+
+    @In
+    private NUIManager nuiManager;
+
+
+    /**
+     * Used to display the death screen, and apply modifications to it.
+     * <p>
+     * Sent when an entity dies
+     * Filters on {@link ShrineComponent}
+     *
+     * @see EntityDeathEvent
+     */
+    @ReceiveEvent(components = ShrineComponent.class)
+    public void onEntityDeath(EntityDeathEvent event, EntityRef entity) {
+        DeathScreen deathScreen = nuiManager.pushScreen("Engine:DeathScreen", DeathScreen.class);
+    }
+
+}

--- a/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
+++ b/src/main/java/org/terasology/gooeyDefence/ui/DeathScreenSystem.java
@@ -25,8 +25,6 @@ import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.WidgetUtil;
 import org.terasology.rendering.nui.layers.ingame.DeathScreen;
-import org.terasology.rendering.nui.widgets.UIButton;
-import org.terasology.rendering.nui.widgets.UILabel;
 
 /**
  * Handles overwriting the death screen to allow
@@ -48,7 +46,16 @@ public class DeathScreenSystem extends BaseComponentSystem {
      */
     @ReceiveEvent(components = ShrineComponent.class)
     public void onEntityDeath(EntityDeathEvent event, EntityRef entity) {
-        DeathScreen deathScreen = nuiManager.pushScreen("Engine:DeathScreen", DeathScreen.class);
+        if (!nuiManager.isOpen("Engine:DeathScreen")) {
+            DeathScreen deathScreen = nuiManager.pushScreen("Engine:DeathScreen", DeathScreen.class);
+            WidgetUtil.trySubscribe(deathScreen, "retry", widget -> {
+                triggerReset();
+            });
+        }
+    }
+
+    private void triggerReset() {
+        nuiManager.closeScreen("Engine:DeathScreen");
     }
 
 }


### PR DESCRIPTION
This adds a screen for game over, and a method to reset the world and try again.

## Test
Build a few towers, destroy the field & otherwise make changes to the world.
Spawn in some enemies (if not using PR #27 this is done by interacting with or placing any block)
Have the enemies reach the shrine and, once the health reaches zero, the screen should appear
On the screen, check that all three buttons work.

The reset button should clear the world, reset money and shrine health and then rebuild the default field. The others are self explanatory 