### PR TITLE
Remove unused import: ElevationCompatibilityProvider

### DIFF
--- a/src/main/java/org/terasology/gooeyDefence/worldGeneration/GooeyDefenceWorldGenerator.java
+++ b/src/main/java/org/terasology/gooeyDefence/worldGeneration/GooeyDefenceWorldGenerator.java
@@ -27,7 +27,6 @@ import org.terasology.gooeyDefence.worldGeneration.rasterizers.ShrineRasterizer;
 import org.terasology.gooeyDefence.worldGeneration.rasterizers.WorldSurfaceRasterizer;
 import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
-import org.terasology.world.generation.ElevationCompatibilityProvider;
 import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;


### PR DESCRIPTION
This class is about to be removed from the engine, so the import here needs to be removed first.