### PR TITLE
fix: don't allow gooeys to climb over blocks

### DIFF
--- a/src/main/java/org/terasology/gooeyDefence/movement/EnemyWalkingPlugin.java
+++ b/src/main/java/org/terasology/gooeyDefence/movement/EnemyWalkingPlugin.java
@@ -85,7 +85,7 @@ public class EnemyWalkingPlugin extends WalkingPlugin {
      * @return True if the movement is vertically possible.
      */
     private boolean isVerticallyReachable(Vector3ic to, Vector3ic from) {
-        return !isMovementHorizontal(to, from) && to.distanceSquared(from) <= 1;
+        return isMovementHorizontal(to, from);
     }
 
     /**


### PR DESCRIPTION
### Motivation

IMO part of the fun when playing a tower defense gameplay is to find strategically good places to build towers to most efficiently impact the oncoming waves. This does not work as well if the enemies can basically just walk in a straight line towards their goal, which is the case with the current arena maze being only one block high and the current movement implementation allowing the enemy gooeys to climb over them.

An alternative common tower defense mode is a completely free arena where the enemy waves can by default intentionally walk in a straight line and the player has to create a maze themselves. However, due to the arena design including a maze, I don't think that's the intentional mode here.

### What this PR does

It reduces the vertical movement range of the oncoming waves to staying on the same level only. Thus, they cannot climb over the maze blocks and need to find their way through it instead, providing the player with more options to strategically place towers.