### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/gooeyDefence/towers/components/TowerMultiBlockComponent.java
+++ b/src/main/java/org/terasology/gooeyDefence/towers/components/TowerMultiBlockComponent.java
@@ -15,7 +15,7 @@ import org.terasology.gestalt.entitysystem.component.Component;
  */
 @ForceBlockActive
 public class TowerMultiBlockComponent implements Component<TowerMultiBlockComponent> {
-    private EntityRef towerEntity = EntityRef.NULL;
+    public EntityRef towerEntity = EntityRef.NULL;
 
     public EntityRef getTowerEntity() {
         return towerEntity;


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191